### PR TITLE
Increased compatibility with 64 bit compilers

### DIFF
--- a/source/mmap.c
+++ b/source/mmap.c
@@ -2,6 +2,9 @@
 #include <windows.h>
 #include <sys/types.h>
 #include <errno.h>
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#endif
 #include <sys/stat.h>
 #include <stdio.h>
 


### PR DESCRIPTION
fstat did not give 64 bit results if it could, so I defined _FILE_OFFSET_BITS for giving 64 bit results if it can.