### PR TITLE
Solved error: too few arguments to function ‘mkdir’

### DIFF
--- a/source/shm_open.c
+++ b/source/shm_open.c
@@ -24,7 +24,7 @@ shm_open (const char *__name, int __oflag, mode_t __mode)
   foldername[strlen (systemdrive) + strlen (tempshm)] = 0;
 
   _get_errno (&error_value);
-  mkdir (foldername);
+  CreateDirectory (foldername, NULL);
   _set_errno (error_value);
 
   filename =


### PR DESCRIPTION
Changed files:
shm_open.c
Problems solved:
error: too few arguments to function ‘mkdir’