### PR TITLE
Solved posix_spawn's and posix_spawnp's argvToCommandLine invalid size

### DIFF
--- a/source/posix_spawn.c
+++ b/source/posix_spawn.c
@@ -116,6 +116,7 @@ argvToCommandLine (char *const argv[])
 	  size++;
 	}
     }
+  size += *arg == 0;
   while (*arg)
     {
       eArg = argvToCommandLinePart (*arg);

--- a/source/posix_spawnp.c
+++ b/source/posix_spawnp.c
@@ -116,6 +116,7 @@ argvToCommandLine (char *const argv[])
 	  size++;
 	}
     }
+  size += *arg == 0;
   while (*arg)
     {
       eArg = argvToCommandLinePart (*arg);


### PR DESCRIPTION
Changed files:
posix_spawn.c
posix_spawnp.c
Problems solved:
posix_spawn's and posix_spawnp's argvToCommandLine invalid size